### PR TITLE
Fixes: get function_name from the context object, skip ephemeral dims; add SIGNALFX_SEND_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Add this line to the top of your file:
 require 'signalfx/lambda'
 ```
 
-To use the wrapper, register `source.SignalFx::Lambda::Tracing.wrapped_handler`
-in the console, where `source` is your Ruby source file. Then somewhere after
+To use the wrapper, put `source.SignalFx::Lambda.wrapped_handler` as the handler
+in the AWS console, where `source` is your Ruby source file (when you use AWS online
+code editor the `source` is `lambda_function` and a complete handler value is
+`lambda_function.SignalFx::Lambda.wrapped_handler`). Then somewhere after
 your handler function definition, the function can be registered to be
 automatically traced:
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ ingest endpoint (https://ingest.{REALM}.signalfx.com). To determine what realm
 you are in, check your profile page in the SignalFx web application (click the
 avatar in the upper right and click My Profile).
 
+Send operation timeout (in seconds) can be specified with `SIGNALFX_SEND_TIMEOUT`
+environment variable. Default value is 1 second.
+ 
 ## Trace and tags
 
 The wrapper will generate a trace per function invocation. The parent span will

--- a/lib/signalfx/lambda/metrics.rb
+++ b/lib/signalfx/lambda/metrics.rb
@@ -81,8 +81,9 @@ module SignalFx
         def init_client
           access_token = ENV['SIGNALFX_ACCESS_TOKEN']
           ingest_endpoint = ENV['SIGNALFX_METRICS_URL'] || ENV['SIGNALFX_ENDPOINT_URL'] || 'https://ingest.signalfx.com'
+          timeout = ENV['SIGNALFX_SEND_TIMEOUT'] || 1
 
-          @client = SignalFx.new access_token, ingest_endpoint: ingest_endpoint
+          @client = SignalFx.new access_token, ingest_endpoint: ingest_endpoint, timeout: timeout
         end
       end
 

--- a/lib/signalfx/lambda/tracing.rb
+++ b/lib/signalfx/lambda/tracing.rb
@@ -12,7 +12,7 @@ module SignalFx
         attr_accessor :tracer, :reporter
 
         def wrap_function(event:, context:, &block)
-          init_tracer(event) if !@tracer # avoid initializing except on a cold start
+          init_tracer(context) if !@tracer # avoid initializing except on a cold start
 
           tags = SignalFx::Lambda.fields
           tags['component'] = SignalFx::Lambda::COMPONENT
@@ -41,17 +41,17 @@ module SignalFx
         end
 
         def wrapped_handler(event:, context:)
-          wrap_function(event, context, &@handler)
+          wrap_function(event: event, context: context, &@handler)
         end
 
         def register_handler(&handler)
           @handler = handler
         end
 
-        def init_tracer(event)
+        def init_tracer(context)
           access_token = ENV['SIGNALFX_ACCESS_TOKEN']
           ingest_url = get_ingest_url
-          service_name = ENV['SIGNALFX_SERVICE_NAME'] || event.function_name
+          service_name = ENV['SIGNALFX_SERVICE_NAME'] || context.function_name
           @span_prefix = ENV['SIGNALFX_SPAN_PREFIX'] || 'lambda_ruby_'
 
           # configure the trace reporter

--- a/lib/signalfx/lambda/version.rb
+++ b/lib/signalfx/lambda/version.rb
@@ -1,5 +1,5 @@
 module SignalFx
   module Lambda
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
  * get AWS lambda function name from the context object
  * do not use `aws_request_id` nor `log_stream_name` as metric dimensions as they change all the time
  * fix `wrap_function` call
  * add SIGNALFX_SEND_TIMEOUT